### PR TITLE
Patch 1

### DIFF
--- a/src/grammar/frag_geom.pest
+++ b/src/grammar/frag_geom.pest
@@ -1,13 +1,13 @@
 # hidden tokens
-rsep = _{ "-" }
 bopen = _{ "[" }
 bclose = _{ "]" }
+rsep = _{ "-" }
 usep = _{ ":" }
 dopen = _{ "{" }
 dclose = _{ "} }
 
-len = { len_range | single_len }
-  len_range = @{ ASCII_DIGIT+ ~ rsep ~ ASCII_DIGIT+ }
+len = _{ len_range | single_len }
+  len_range = { ASCII_DIGIT+ ~ rsep ~ ASCII_DIGIT+ }
   single_len = { ASCII_DIGIT+ }
 
 bounded_segment = { 
@@ -20,8 +20,8 @@ bounded_segment = {
   bounded_umi_segment = { "u" ~ bopen ~ len ~ bclose }
   bounded_read_segment = { "r" ~ bopen ~ len ~ bclose }
   bounded_barcode_segment = { "b" ~ bopen ~ len ~ bclose }
-  bounded_fixedseq_segment = { "f" ~ bopen ~ nucstr ~ bclose }
-    nucstr = { ("A" | "C" | "G" | "T")+ }
+  bounded_fixedseq_segment = { "f" ~ bopen ~ nucseq ~ bclose }
+    nucseq = { ("A" | "C" | "G" | "T")+ }
   bounded_discard_segment = { "x" ~ bopen ~ len ~ bclose }
 
 unbounded_segment = {
@@ -37,6 +37,6 @@ unbounded_segment = {
 
 read_desc = { dopen ~ ( unbounded_segment | ( bounded_segment+ ~ unbounded_segment? ) ) ~ dclose }
 frag_desc = _{ read_1_desc ~ read_2_desc }
-  read_1_desc = { "1" ~ read_desc }
-  read_2_desc = { "2" ~ read_desc }
+  read_1_desc = ${ "1" ~ read_desc }
+  read_2_desc = ${ "2" ~ read_desc }
 

--- a/src/grammar/frag_geom.pest
+++ b/src/grammar/frag_geom.pest
@@ -36,7 +36,7 @@ unbounded_segment = {
   unbounded_discard_segment = { "x" ~ usep }
 
 read_desc = { dopen ~ ( unbounded_segment | ( bounded_segment+ ~ unbounded_segment? ) ) ~ dclose }
-frag_desc = _{ read_1_desc ~ read_2_desc }
+frag_desc = { read_1_desc ~ read_2_desc }
   read_1_desc = ${ "1" ~ read_desc }
   read_2_desc = ${ "2" ~ read_desc }
 

--- a/src/grammar/frag_geom.pest
+++ b/src/grammar/frag_geom.pest
@@ -36,7 +36,7 @@ unbounded_segment = {
   unbounded_discard_segment = { "x" ~ usep }
 
 read_desc = { dopen ~ ( unbounded_segment | ( bounded_segment+ ~ unbounded_segment? ) ) ~ dclose }
-frag_desc = { read_1_desc ~ read_2_desc }
+frag_desc = { SOI ~ read_1_desc ~ read_2_desc ~ EOI }
   read_1_desc = ${ "1" ~ read_desc }
   read_2_desc = ${ "2" ~ read_desc }
 

--- a/src/grammar/frag_geom.pest
+++ b/src/grammar/frag_geom.pest
@@ -4,7 +4,7 @@ bclose = _{ "]" }
 rsep = _{ "-" }
 usep = _{ ":" }
 dopen = _{ "{" }
-dclose = _{ "} }
+dclose = _{ "}" }
 
 len = _{ len_range | single_len }
   len_range = { ASCII_DIGIT+ ~ rsep ~ ASCII_DIGIT+ }

--- a/src/grammar/frag_geom.pest
+++ b/src/grammar/frag_geom.pest
@@ -1,30 +1,42 @@
-read_num = { "1" | "2" }
-single_len = { ASCII_DIGIT+ }
-len_range = @{ ASCII_DIGIT+ ~ "-" ~ ASCII_DIGIT+ }
-len = { (len_range | single_len) }
-nucstr = { ("A" | "C" | "G" | "T")+ }
-bounded_barcode_segment = { "b[" ~ len ~ "]" }
-bounded_umi_segment = { "u[" ~ len ~ "]" }
-bounded_fixedseq_segment = { "f[" ~ nucstr ~ "]" }
-bounded_read_segment = { "r[" ~ len ~ "]" }
-bounded_discard_segment = { "x[" ~ len ~ "]" }
-unbounded_barcode_segment = { "b:" }
-unbounded_umi_segment = { "u:" }
-unbounded_read_segment = { "r:" }
-unbounded_discard_segment = { "x:" }
+# hidden tokens
+rsep = _{ "-" }
+bopen = _{ "[" }
+bclose = _{ "]" }
+usep = _{ ":" }
+dopen = _{ "{" }
+dclose = _{ "} }
 
-bounded_segment = { (bounded_umi_segment |
-bounded_read_segment |
-bounded_barcode_segment |
-bounded_fixedseq_segment |
-bounded_discard_segment) }
+len = { len_range | single_len }
+  len_range = @{ ASCII_DIGIT+ ~ rsep ~ ASCII_DIGIT+ }
+  single_len = { ASCII_DIGIT+ }
 
-unbounded_segment = { (unbounded_umi_segment |
-unbounded_read_segment |
-unbounded_barcode_segment |
-unbounded_discard_segment) }
+bounded_segment = { 
+  bounded_umi_segment |
+  bounded_read_segment |
+  bounded_barcode_segment |
+  bounded_fixedseq_segment |
+  bounded_discard_segment 
+}
+  bounded_umi_segment = { "u" ~ bopen ~ len ~ bclose }
+  bounded_read_segment = { "r" ~ bopen ~ len ~ bclose }
+  bounded_barcode_segment = { "b" ~ bopen ~ len ~ bclose }
+  bounded_fixedseq_segment = { "f" ~ bopen ~ nucstr ~ bclose }
+    nucstr = { ("A" | "C" | "G" | "T")+ }
+  bounded_discard_segment = { "x" ~ bopen ~ len ~ bclose }
 
-read_desc = { "{" ~ ((unbounded_segment) | (bounded_segment)+ ~ (unbounded_segment){0,1}) ~ "}" }
-read_1_desc = { "1" ~ read_desc }
-read_2_desc = { "2" ~ read_desc }
+unbounded_segment = {
+  unbounded_umi_segment |
+  unbounded_read_segment |
+  unbounded_barcode_segment |
+  unbounded_discard_segment
+}
+  unbounded_umi_segment = { "u" ~ usep }
+  unbounded_read_segment = { "r" ~ usep }
+  unbounded_barcode_segment = { "b" ~ usep }
+  unbounded_discard_segment = { "x" ~ usep }
+
+read_desc = { dopen ~ ( unbounded_segment | ( bounded_segment+ ~ unbounded_segment? ) ) ~ dclose }
 frag_desc = _{ read_1_desc ~ read_2_desc }
+  read_1_desc = { "1" ~ read_desc }
+  read_2_desc = { "2" ~ read_desc }
+


### PR DESCRIPTION
Some suggested changes to the grammar, based on my experience (and to some degree personal preference):

1. Factor out delimiter tokens into hidden rules. There's not really any reason to have the parser produce these tokens.
2. Marked the top-level rules as compound-atomic. I am intuiting here that you do not want to allow whitespace within a read geometry string. You don't really need this since you did not define a `WHITESPACE` rule but I think it's good to use it anyway because 1) it shows intention and 2) it future-proofs you in case you add a `WHITESPACE` rule later.
3. Organized the rules into a structure that mirrors the parse tree they produce.
4. Removed some unnecessary parens and changed `{0,1}` to `?`.
